### PR TITLE
make perkeo on title screen optional and configurable

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -7,19 +7,25 @@ function Card:resize(mod, force_save)
 end
 
 -- Get the mod's config
-local config = SMODS.current_mod.config or {}
--- Set default config value if not present
-if config.title == nil then
-    config.title = true
+local perkolator_config = SMODS.current_mod.config
+-- Create config if it doesn't exist
+if not perkolator_config then
+    perkolator_config = {
+        title = true
+    }
+    SMODS.current_mod.config = perkolator_config
+    -- Set default value if config exists but title setting doesn't
+elseif perkolator_config.title == nil then
+    perkolator_config.title = true
 end
 -- Store initial config state for comparison
-local perkolator_enabled = copy_table(config)
+local perkolator_enabled = copy_table(perkolator_config)
 
 -- Add restart function to determine if restart is needed
 function G.FUNCS.perkolator_restart()
     local config_changed = false
     for k, v in pairs(perkolator_enabled) do
-        if v ~= config[k] then
+        if v ~= perkolator_config[k] then
             config_changed = true
             break
         end
@@ -52,7 +58,7 @@ SMODS.current_mod.config_tab = function()
         }}
     }, create_toggle({
         label = "Perkeo Card on Title Screen (Requires Restart)",
-        ref_table = config,
+        ref_table = perkolator_config,
         ref_value = "title",
         callback = G.FUNCS.perkolator_restart
     })}

--- a/main.lua
+++ b/main.lua
@@ -79,7 +79,7 @@ SMODS.current_mod.config_tab = function()
 end
 
 -- Modify the main menu only if the title screen change is enabled
-if config["title"] then
+if perkolator_config["title"] then
     local mainmenuref2 = Game.main_menu
     Game.main_menu = function(change_context)
         local ret = mainmenuref2(change_context)

--- a/main.lua
+++ b/main.lua
@@ -6,29 +6,101 @@ function Card:resize(mod, force_save)
     self:set_sprites(self.config.center, self.base.id and self.config.card)
 end
 
-local mainmenuref2 = Game.main_menu
-Game.main_menu = function(change_context)
+-- Get the mod's config
+local config = SMODS.current_mod.config or {}
+-- Set default config value if not present
+if config.title == nil then
+    config.title = true
+end
+-- Store initial config state for comparison
+local perkolator_enabled = copy_table(config)
 
-    local ret = mainmenuref2(change_context)
+-- Add restart function to determine if restart is needed
+function G.FUNCS.perkolator_restart()
+    local config_changed = false
+    for k, v in pairs(perkolator_enabled) do
+        if v ~= config[k] then
+            config_changed = true
+            break
+        end
+    end
 
-        --Replace j_unik_unik with 'j_perkeo' or any other card
-    local newcard = SMODS.create_card({key='j_perkeo', edition='e_negative',area = G.title_top})
-	G.title_top.T.w = G.title_top.T.w * 1.7675
-	G.title_top.T.x = G.title_top.T.x - 0.8
-    G.title_top:emplace(newcard)
-    newcard:start_materialize()
-    newcard:resize(1.1 * 1.2)
-    newcard.no_ui = true
-    return ret
+    if config_changed then
+        SMODS.full_restart = 1
+    else
+        SMODS.full_restart = 0
+    end
+end
+
+-- Add a configuration menu for the Perkolating mod
+SMODS.current_mod.config_tab = function()
+    local perkolator_nodes = {{
+        n = G.UIT.R,
+        config = {
+            align = "cm"
+        },
+        nodes = {{
+            n = G.UIT.O,
+            config = {
+                object = DynaText({
+                    string = "Options:",
+                    colours = {G.C.WHITE},
+                    shadow = true,
+                    scale = 0.4
+                })
+            }
+        }}
+    }, create_toggle({
+        label = "Perkeo Card on Title Screen (Requires Restart)",
+        ref_table = config,
+        ref_value = "title",
+        callback = G.FUNCS.perkolator_restart
+    })}
+
+    return {
+        n = G.UIT.ROOT,
+        config = {
+            emboss = 0.05,
+            minh = 6,
+            r = 0.1,
+            minw = 10,
+            align = "cm",
+            padding = 0.2,
+            colour = G.C.BLACK
+        },
+        nodes = perkolator_nodes
+    }
+end
+
+-- Modify the main menu only if the title screen change is enabled
+if config["title"] then
+    local mainmenuref2 = Game.main_menu
+    Game.main_menu = function(change_context)
+        local ret = mainmenuref2(change_context)
+
+        -- Replace j_unik_unik with 'j_perkeo' or any other card
+        local newcard = SMODS.create_card({
+            key = 'j_perkeo',
+            edition = 'e_negative',
+            area = G.title_top
+        })
+        G.title_top.T.w = G.title_top.T.w * 1.7675
+        G.title_top.T.x = G.title_top.T.x - 0.8
+        G.title_top:emplace(newcard)
+        newcard:start_materialize()
+        newcard:resize(1.1 * 1.2)
+        newcard.no_ui = true
+        return ret
+    end
 end
 
 SMODS.current_mod.optional_features = function()
     return {
-      retrigger_joker = true
+        retrigger_joker = true
     }
-  end
-  
-  --loads mod componets
+end
+
+-- loads mod componets
 
 assert(SMODS.load_file('jokers.lua'))()
 assert(SMODS.load_file('rarity.lua'))()


### PR DESCRIPTION
Renamed the config variable in the second commit because of this crash:

```
INFO - [G] 2025-04-16 05:46:39 :: ERROR :: StackTrace :: Oops! The game crashed
[SMODS ReduxArcanum "/api/alchemicalAPI.lua"]:147: attempt to index field 'config' (a nil value)
Stack Traceback
===============
(1) Lua local 'handler' at file 'main.lua:612'
	Local variables:
	 msg = string: "[SMODS ReduxArcanum \"/api/alchemicalAPI.lua\"]:147: attempt to index field 'config' (a nil value)"
	 (*temporary) = Lua function '?' (defined at line 31 of chunk [SMODS _ "src/logging.lua"])
	 (*temporary) = number: 2.32448e-314
	 (*temporary) = string: "Oops! The game crashed\
"
(2) LÖVE metamethod at file 'boot.lua:352'
	Local variables:
	 errhand = Lua function '?' (defined at line 598 of chunk main.lua)
	 handler = Lua function '?' (defined at line 598 of chunk main.lua)
(3) Lua method 'loc_vars' at file '/api/alchemicalAPI.lua:147' (from mod with id ReduxArcanum)
	Local variables:
	 self = table: 0x0304da83c0  {original_mod:table: 0x011d59be50, _discovered_unlocked_overwritten:true, discovered:false, prefix_config:table: 0x0304da86f0, original_key:sulfur (more...)}
	 info_queue = table: 0x0304e394f8  {}
	 card = table: 0x01325190c0  {ability:table: 0x03048ae048, fake_card:true}
	 (*temporary) = nil
	 (*temporary) = string: "table"
	 (*temporary) = table: 0x0304cf82d8  {extra:4}
	 (*temporary) = table: 0x0304cf82d8  {extra:4}
	 (*temporary) = number: 2.28258e-314
	 (*temporary) = table: 0x0304cf82d8  {extra:4}
	 (*temporary) = string: "attempt to index field 'config' (a nil value)"
(4) Lua method 'generate_ui' at Steamodded file 'src/game_object.lua:1070'
	Local variables:
	 self = table: 0x0304da83c0  {original_mod:table: 0x011d59be50, _discovered_unlocked_overwritten:true, discovered:false, prefix_config:table: 0x0304da86f0, original_key:sulfur (more...)}
	 info_queue = table: 0x0304e394f8  {}
	 card = table: 0x01325190c0  {ability:table: 0x03048ae048, fake_card:true}
	 desc_nodes = table: 0x0137eb1e18  {}
	 specific_vars = nil
	 full_UI_table = table: 0x0137daef88  {badges:table: 0x0137f66828, info:table: 0x0118a5c168, card_type:Tag, type:table: 0x0137f667e0, name:table: 0x0137eaf528, main:table: 0x0118a5c120 (more...)}
	 target = table: 0x01525cceb0  {vars:table: 0x01525ccef8, nodes:table: 0x0137eb1e18, key:c_ReduxArcanum_sulfur, type:descriptions, set:Alchemical}
	 res = table: 0x03048a21d8  {}
(5) Lua global 'generate_card_ui' at file 'functions/common_events.lua:3074'
	Local variables:
	 _c = table: 0x0304da83c0  {original_mod:table: 0x011d59be50, _discovered_unlocked_overwritten:true, discovered:false, prefix_config:table: 0x0304da86f0, original_key:sulfur (more...)}
	 full_UI_table = table: 0x0137daef88  {badges:table: 0x0137f66828, info:table: 0x0118a5c168, card_type:Tag, type:table: 0x0137f667e0, name:table: 0x0137eaf528, main:table: 0x0118a5c120 (more...)}
	 specific_vars = nil
	 card_type = nil
	 badges = nil
	 hide_desc = nil
	 main_start = nil
	 main_end = nil
	 card = nil
	 first_pass = nil
	 desc_nodes = table: 0x0137eb1e18  {}
	 name_override = nil
	 info_queue = table: 0x0304e394f8  {}
	 loc_vars = table: 0x0137eb1e60  {}
	 cfg = table: 0x0304da85c0  {extra:4}
(6) Lua global 'generate_card_ui' at file 'functions/common_events.lua:3543'
	Local variables:
	 _c = table: 0x0304ea5838  {conifg:table: 0x0304ea6850, loc_txt:table: 0x0304ea6798, set_ability:function: 0x0304ea68c8, discovered:true, alerted:false, mod:table: 0x0118d9df88 (more...)}
	 full_UI_table = table: 0x0137daef88  {badges:table: 0x0137f66828, info:table: 0x0118a5c168, card_type:Tag, type:table: 0x0137f667e0, name:table: 0x0137eaf528, main:table: 0x0118a5c120 (more...)}
	 specific_vars = table: 0x0137daef40  {}
	 card_type = string: "Tag"
	 badges = nil
	 hide_desc = nil
	 main_start = nil
	 main_end = nil
	 card = table: 0x0137e94df8  {triggered:false, pos:table: 0x0304ea6b08, ID:0, tally:0, config:table: 0x0137e94e40, key:tag_bplus_enhanced, ability:table: 0x0304ef10b0, tag_sprite:table: 0x011d593e58 (more...)}
	 first_pass = boolean: true
	 desc_nodes = table: 0x0118a5c120  {1:table: 0x0315983af0, 2:table: 0x0157fe0140, 3:table: 0x0118a30fe0, 4:table: 0x0304cebda0}
	 name_override = nil
	 info_queue = table: 0x0304e503a8  {1:table: 0x0304da83c0}
	 loc_vars = table: 0x0304e503f0  {}
	 cfg = table: 0x0304ef10b0  {blind_type:Small, bplus_enhanced_tag_mod:c_ReduxArcanum_sulfur, orbital_hand:[poker hand]}
	 (for generator) = C function: builtin#6
	 (for state) = table: 0x0304e503a8  {1:table: 0x0304da83c0}
	 (for control) = number: 1
	 _ = number: 1
	 v = table: 0x0304da83c0  {original_mod:table: 0x011d59be50, _discovered_unlocked_overwritten:true, discovered:false, prefix_config:table: 0x0304da86f0, original_key:sulfur (more...)}
(7) Lua method 'get_uibox_table' at file 'tag.lua:580'
	Local variables:
	 self = table: 0x0137e94df8  {triggered:false, pos:table: 0x0304ea6b08, ID:0, tally:0, config:table: 0x0137e94e40, key:tag_bplus_enhanced, ability:table: 0x0304ef10b0, tag_sprite:table: 0x011d593e58 (more...)}
	 tag_sprite = table: 0x011d593e58  {zoom:true, original_T:table: 0x0304a24df0, velocity:table: 0x011d6822e8, role:table: 0x0118c42d48, alignment:table: 0x011895e838, atlas:table: 0x0304e95f08 (more...)}
	 vars_only = nil
	 name_to_check = nil
	 loc_vars = table: 0x0137daef40  {}
(8) Lua function '?' at file 'functions/button_callbacks.lua:2840' (best guess)
	Local variables:
	 e = table: 0x0132504238  {original_T:table: 0x0137f6e988, velocity:table: 0x0152554060, UIBox:table: 0x0118d387c8, alignment:table: 0x0137fbb490, pinch:table: 0x015252c520 (more...)}
(9) Lua method 'update' at file 'engine/ui.lua:960'
	Local variables:
	 self = table: 0x0132504238  {original_T:table: 0x0137f6e988, velocity:table: 0x0152554060, UIBox:table: 0x0118d387c8, alignment:table: 0x0137fbb490, pinch:table: 0x015252c520 (more...)}
	 dt = number: 0.0337165
(10) Lua upvalue 'gameUpdateRef' at file 'game.lua:3079'
	Local variables:
	 self = table: 0x011879b0d8  {button_mapping:table: 0x01187e7e90, PREV_GARB:0, F_ENABLE_PERF_OVERLAY:false, F_CTA:false, F_SKIP_TUTORIAL:false, F_BASIC_CREDITS:false, F_EXTERNAL_LINKS:true (more...)}
	 dt = number: 0.00842914
	 http_resp = nil
	 move_dt = number: 0.00842914
	 (for generator) = C function: next
	 (for state) = table: 0x011879ccb0  {1:table: 0x0118b20ee0, 2:table: 0x0152598c68, 3:table: 0x01525029f0, 4:table: 0x0304fae940, 5:table: 0x0304fae8d8, 6:table: 0x0137e0b2a8, 7:table: 0x0137e11b30 (more...)}
	 (for control) = userdata: NULL
	 k = number: 467
	 v = table: 0x0132504238  {original_T:table: 0x0137f6e988, velocity:table: 0x0152554060, UIBox:table: 0x0118d387c8, alignment:table: 0x0137fbb490, pinch:table: 0x015252c520 (more...)}
(11) Lua upvalue 'upd' at Steamodded file 'src/ui.lua:84'
	Local variables:
	 self = table: 0x011879b0d8  {button_mapping:table: 0x01187e7e90, PREV_GARB:0, F_ENABLE_PERF_OVERLAY:false, F_CTA:false, F_SKIP_TUTORIAL:false, F_BASIC_CREDITS:false, F_EXTERNAL_LINKS:true (more...)}
	 dt = number: 0.00842914
(12) Lua upvalue 'upd' at file 'main.lua:1804'
	Local variables:
	 self = table: 0x011879b0d8  {button_mapping:table: 0x01187e7e90, PREV_GARB:0, F_ENABLE_PERF_OVERLAY:false, F_CTA:false, F_SKIP_TUTORIAL:false, F_BASIC_CREDITS:false, F_EXTERNAL_LINKS:true (more...)}
	 dt = number: 0.00842914
(13) Lua upvalue 'game_updateref' at file 'Grim.lua:3894' (from mod with id GRM)
	Local variables:
	 self = table: 0x011879b0d8  {button_mapping:table: 0x01187e7e90, PREV_GARB:0, F_ENABLE_PERF_OVERLAY:false, F_CTA:false, F_SKIP_TUTORIAL:false, F_BASIC_CREDITS:false, F_EXTERNAL_LINKS:true (more...)}
	 dt = number: 0.00842914
(14) Lua method 'update' at file 'LobotomyCorp.lua:1905' (from mod with id LobotomyCorp)
	Local variables:
	 self = table: 0x011879b0d8  {button_mapping:table: 0x01187e7e90, PREV_GARB:0, F_ENABLE_PERF_OVERLAY:false, F_CTA:false, F_SKIP_TUTORIAL:false, F_BASIC_CREDITS:false, F_EXTERNAL_LINKS:true (more...)}
	 dt = number: 0.00842914
(15) Lua upvalue 'oldupd' at file 'main.lua:995'
	Local variables:
	 dt = number: 0.00842914
(16) Lua field 'update' at file 'main.lua:1837'
	Local variables:
	 dt = number: 0.00842914
(17) Lua function '?' at file 'main.lua:934' (best guess)
(18) global C function 'xpcall'
(19) LÖVE function at file 'boot.lua:377' (best guess)
	Local variables:
	 func = Lua function '?' (defined at line 905 of chunk main.lua)
	 inerror = boolean: true
	 deferErrhand = Lua function '(LÖVE Function)' (defined at line 348 of chunk [love "boot.lua"])
	 earlyinit = Lua function '(LÖVE Function)' (defined at line 355 of chunk [love "boot.lua"])

INFO - [G] file not found: functions/button_callbacks.lua: No such file or directory
INFO - [G] file not found: main.lua: No such file or directory
INFO - [G] file not found: main.lua: No such file or directory
INFO - [G] 2025-04-16 05:46:39 :: INFO  :: StackTrace :: Additional Context:
Balatro Version: 1.0.1o-FULL
Modded Version: 1.0.0~BETA-0410b-STEAMODDED
LÖVE Version: 11.5.0
Lovely Version: 0.7.1
Platform: OS X
Steamodded Mods:
    1: Grim by mathguy [ID: GRM, Version: 1.1.6a, Uses Lovely]
    2: Fusion Jokers by itayfeder, Lyman [ID: FusionJokers, Priority: -10000]
    3: ExtraCredit by CampfireCollective [ID: extracredit, Priority: 1, Version: 1.3.0, Uses Lovely]
    4: Betmma Jokers by Betmma [ID: BetmmaJokers]
    5: Balatro+ by SomeCoder99 [ID: balatro_plus, Version: 1.0.2-a, Uses Lovely]
    6: Lobotomy Corporation by Mysthaps [ID: LobotomyCorp, Version: 1.1.2, Uses Lovely]
    7: Redux Arcanum by itayfeder, Lyman, Jumbo [ID: ReduxArcanum, Version: 2.0.0~PreRelease5, Uses Lovely]
    8: Talisman by MathIsFun_, Mathguy24, jenwalter666, cg-223 [ID: Talisman, Version: 2.2.0~dev, Uses Lovely]
        Break Infinity: bignumber
    9: Mossed by Larantula, Jetziel [ID: mossed, Priority: -20, Version: 1.0.0]
Lovely Mods:
```